### PR TITLE
Feature/add user delete UI

### DIFF
--- a/syosekiroku/Views/Screens/Main/Profile/ProfileView.swift
+++ b/syosekiroku/Views/Screens/Main/Profile/ProfileView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ProfileView: View {
     @EnvironmentObject var auth: AuthManager
+    @State private var isShowingDeleteAlert = false
 
     var userDB: UserDatabaseService {
         UserDatabaseService(supabase: auth.supabase)
@@ -81,14 +82,25 @@ struct ProfileView: View {
                 text: "アカウントを削除", fontColor: .white,
                 backgroundColor: .gray, isDisabled: false
             ) {
-                if let userId = auth.user?.id {
-                    Task {
-                        // auth.userからの削除は行わない(管理者権限でしか行えないため)
-                        await userDB.deleteUser(userId: userId)
-                        await auth.signOut()
-                        auth.isAuth = false
+                isShowingDeleteAlert = true
+            }
+            .alert(
+                "アカウントを削除しますか？",
+                isPresented: $isShowingDeleteAlert
+            ) {
+                Button("削除する", role: .destructive) {
+                    if let userId = auth.user?.id {
+                        Task {
+                            // auth.userからの削除は行わない(管理者権限でしか行えないため)
+                            await userDB.deleteUser(userId: userId)
+                            await auth.signOut()
+                            auth.isAuth = false
+                        }
                     }
                 }
+                Button("キャンセル", role: .cancel) {}
+            } message: {
+                Text("この操作は取り消せません。")
             }
         }
         .padding()

--- a/syosekiroku/Views/Screens/Main/Profile/ProfileView.swift
+++ b/syosekiroku/Views/Screens/Main/Profile/ProfileView.swift
@@ -4,6 +4,10 @@ import SwiftUI
 struct ProfileView: View {
     @EnvironmentObject var auth: AuthManager
 
+    var userDB: UserDatabaseService {
+        UserDatabaseService(supabase: auth.supabase)
+    }
+
     var body: some View {
         VStack(spacing: 20) {
             if let user = auth.user {
@@ -70,6 +74,20 @@ struct ProfileView: View {
             ) {
                 Task {
                     await auth.signOut()
+                }
+            }
+
+            CustomWideButton(
+                text: "アカウントを削除", fontColor: .white,
+                backgroundColor: .gray, isDisabled: false
+            ) {
+                if let userId = auth.user?.id {
+                    Task {
+                        // auth.userからの削除は行わない(管理者権限でしか行えないため)
+                        await userDB.deleteUser(userId: userId)
+                        await auth.signOut()
+                        auth.isAuth = false
+                    }
                 }
             }
         }


### PR DESCRIPTION
・アカウント削除用のボタンとアラートの追加
・アカウント削除処理の連携
(追記)
・auth.userのデータは管理者権限のみ削除可能なので、今回はauth.usersの削除は行わずにpublic.usersのみ削除した