### PR TITLE
認証の状態確認をAuthmanagerからViewで行うように変更

### DIFF
--- a/syosekiroku/Manager/AuthManager.swift
+++ b/syosekiroku/Manager/AuthManager.swift
@@ -27,47 +27,6 @@ final class AuthManager: ObservableObject {
             supabaseURL: supabaseURL,
             supabaseKey: supabaseAnonKey
         )
-
-        Task {
-            await self.checkSession()
-
-            for await (event, _) in supabase.auth.authStateChanges {
-                switch event {
-                case .signedIn:
-                    isAuth = true
-                    if let authUser = supabase.auth.currentUser {
-                        let appUser = AppUser(from: authUser)
-                        user = appUser
-                    }
-                case .signedOut:
-                    isAuth = false
-                    user = nil
-                default:
-                    break
-                }
-            }
-        }
-    }
-
-    private func checkSession() async {
-        do {
-            let _ = try await supabase.auth.session
-            let currentUser = supabase.auth.currentUser
-
-            if currentUser != nil {
-                isAuth = true
-                if let authUser = supabase.auth.currentUser {
-                    let appUser = AppUser(from: authUser)
-                    user = appUser
-                }
-                print("既存のセッションがあります: \(currentUser?.email ?? "no email")")
-            } else {
-                isAuth = false
-                user = nil
-            }
-        } catch {
-            print("checkSession error: \(error)")
-        }
     }
 
     func SigninWithGoogle() async {
@@ -107,7 +66,6 @@ final class AuthManager: ObservableObject {
                 )
             )
 
-            // authStateChangesではuserの更新が間に合わなかったので、ここではcurrentUserを使用
             if let authUser = supabase.auth.currentUser {
                 let appUser = AppUser(from: authUser)
                 user = appUser

--- a/syosekiroku/Views/InitialView.swift
+++ b/syosekiroku/Views/InitialView.swift
@@ -2,17 +2,39 @@
 //  ContentView.swift
 //  syosekiroku
 
-import SwiftUI
 import Supabase
+import SwiftUI
 
 struct InitialView: View {
     @EnvironmentObject var auth: AuthManager
+    var supabase: SupabaseClient {
+        auth.supabase
+    }
+
     var body: some View {
-        Group{
+        Group {
             if !auth.isAuth {
                 SigninView()
             } else {
                 MainStack()
+            }
+        }
+        .task {
+            // 認証状態の監視
+            for await state in supabase.auth.authStateChanges {
+                if [.initialSession, .signedIn, .signedOut].contains(
+                    state.event)
+                {
+                    if state.session != nil {
+                        auth.isAuth = true
+                        if let currentUser = supabase.auth.currentUser {
+                            auth.user = AppUser(from: currentUser)
+                        }
+                    } else {
+                        auth.isAuth = false
+                        auth.user = nil
+                    }
+                }
             }
         }
     }
@@ -20,4 +42,5 @@ struct InitialView: View {
 
 #Preview {
     InitialView()
+        .environmentObject(AuthManager())
 }


### PR DESCRIPTION
・AuthManagerで今までセッションの確認と認証イベントの監視を行なっていたが、InitialViewで行うように変更